### PR TITLE
feat: enable request tracking to be managed by a config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -21,6 +21,8 @@ type Options struct {
 	// after the table record.
 	PrintRequestBody bool `yaml:"printRequestBody"`
 
+	TrackRequests bool `yaml:"trackRequests"`
+
 	Port string `yaml:"port"`
 	Host string `yaml:"host"`
 }

--- a/mokk.yml
+++ b/mokk.yml
@@ -2,7 +2,7 @@ name: Mokk Users Server
 
 options:
   printRequestBody: false
-
+  
 routes:
   - path: users
     method: GET


### PR DESCRIPTION
This PR adds the option to the config file for `trackRequests` which will enable request tracking for the admin API. This value is `false` by default.

