### PR TITLE
feat: add optional delay to routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ It is recommended to create your own config file and provide it to the container
 docker run \
   -p 8080:80 \
   --volume my-app.mokk.yml:/app/mokk.yml \
-  richtoms/mokk:v1.0
+  richtoms/mokk:v1.1
 ```
 
 Alternatively, you can use one of the built-in example APIs found in the `./examples` directory.
@@ -70,6 +70,7 @@ routes:
     method: "GET"
     statusCode: 200
     response: '{"status":"Success","user":{"name":"MockZilla"}}'
+    delay: 100
 ```
 
 ### Routes
@@ -122,12 +123,22 @@ Below is an example config of a route definition with variants:
 
 This feature can be used to provide failure states within the API, along with multiple success states to further your test scenarios.
 
+#### Delay
+
+This feature will allow you to add a number of milliseconds delay to Mokk's response in order to simulate actual response times and even timeouts in your API clients.
+
 ### Options
 
 #### printRequestBody
 
 If enabled, any request with a JSON body will have the contents printed to the console. This feature
 can be useful when debugging what your application is sending to the mocked API.
+
+#### trackRequests
+
+If enabled, any request made to a configured endpoint will be tracked and retrievable from the System API. 
+
+This feature is disabled by default.
 
 
 ## System API

--- a/config/config.go
+++ b/config/config.go
@@ -33,6 +33,7 @@ type Route struct {
 	StatusCode int            `yaml:"statusCode" json:"statusCode"`
 	Response   string         `yaml:"response" json:"response"`
 	Variants   []RouteVariant `yaml:"variants,omitempty" json:"variants"`
+	Delay      int            `yaml:"delay"`
 }
 
 type RouteVariant struct {

--- a/mokk.yml
+++ b/mokk.yml
@@ -27,6 +27,7 @@ routes:
     method: POST
     statusCode: 201
     response: '{"status":"Success","user":{"name":"MockZilla Jr"}}'
+    delay: 500
 
   - path: users/:user
     method: PATCH

--- a/server/json.go
+++ b/server/json.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/gofiber/fiber/v2"
 	"github.com/richtoms/mokk/config"
+	"time"
 )
 
 // JsonHandler provides a Fiber Handler for rendering JSON responses
@@ -45,6 +46,10 @@ func JsonHandler(svr *Server, cfg config.Options, route config.Route) fiber.Hand
 		if cfg.TrackRequests {
 			record := svr.rLog.Record(route, body, res)
 			c.Append("mokk-request-id", record.Id)
+		}
+
+		if route.Delay > 0 {
+			time.Sleep(time.Duration(route.Delay) * time.Millisecond)
 		}
 
 		if len(c.Body()) > 0 {


### PR DESCRIPTION
This PR introduces an optional delay to routes to allow users to simulate slower requests and even API timeouts.